### PR TITLE
Add detector to detect resources in the manifest

### DIFF
--- a/pkg/utils/merge_map.go
+++ b/pkg/utils/merge_map.go
@@ -1,0 +1,13 @@
+package utils
+
+// MergeMap merge several maps into one map, if these maps have the same key,
+// the value in later map will be used
+func MergeMap(maps ...map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
+}

--- a/terraform/detector/detector.go
+++ b/terraform/detector/detector.go
@@ -1,0 +1,14 @@
+package detector
+
+import (
+	artifacts "github.com/kun-lun/artifacts/pkg/apis/manifests"
+	"github.com/kun-lun/infra-producer/storage"
+)
+
+// Detector can detector whether a resource exists. If it exists,
+// `DetectTemplate` will return its terraform script, and
+// `DetectInput` will return related input map
+type Detector interface {
+	DetectTemplate(manifest artifacts.InfraManifest, state storage.State, templatesHolder interface{}) string
+	DetectInput(manifest artifacts.InfraManifest, state storage.State) map[string]interface{}
+}

--- a/terraform/webserver/infra_detector.go
+++ b/terraform/webserver/infra_detector.go
@@ -1,0 +1,64 @@
+package webserver
+
+import (
+	"strconv"
+	"strings"
+
+	artifacts "github.com/kun-lun/artifacts/pkg/apis/manifests"
+	"github.com/kun-lun/infra-producer/storage"
+)
+
+type infraDetector struct{}
+
+func (id infraDetector) DetectTemplate(
+	manifest artifacts.InfraManifest,
+	state storage.State,
+	templatesHolder interface{},
+) string {
+	tmpls := templatesHolder.(templates)
+	template := strings.Join(
+		[]string{
+			tmpls.mysql,
+			tmpls.jumpbox,
+			tmpls.output,
+			tmpls.provider,
+			tmpls.resourceGroup,
+			tmpls.subnet,
+			tmpls.vars,
+			tmpls.vmssServer,
+			tmpls.vnet,
+		},
+		"\n",
+	)
+
+	return template
+}
+
+func (id infraDetector) DetectInput(
+	manifest artifacts.InfraManifest,
+	state storage.State,
+) map[string]interface{} {
+	dbUsername := manifest.Database.Username
+	dbPassword := manifest.Database.Password
+	dbStorage := strconv.Itoa(manifest.Database.Storage)
+	dbCore := strconv.Itoa(manifest.Database.Cores)
+
+	vmCount := strconv.Itoa(manifest.VMGroups[0].Count)
+	vmSize := manifest.VMGroups[0].SKU
+
+	result := map[string]interface{}{
+		"env_name":            state.EnvName,
+		"region":              state.Azure.Region,
+		"database_username":   dbUsername,
+		"database_password":   dbPassword,
+		"storage":             dbStorage,
+		"cores":               dbCore,
+		"web_server_vm_count": vmCount,
+		"web_server_vm_size":  vmSize,
+	}
+	return result
+}
+
+func newInfraDetector() infraDetector {
+	return infraDetector{}
+}

--- a/terraform/webserver/load_balancer_detector.go
+++ b/terraform/webserver/load_balancer_detector.go
@@ -1,0 +1,40 @@
+package webserver
+
+import (
+	artifacts "github.com/kun-lun/artifacts/pkg/apis/manifests"
+	"github.com/kun-lun/infra-producer/storage"
+)
+
+type loadBalancerDetector struct{}
+
+func (lbd loadBalancerDetector) DetectTemplate(
+	manifest artifacts.InfraManifest,
+	state storage.State,
+	templatesHolder interface{},
+) string {
+	lb := manifest.LoadBalancer
+	if lb == nil {
+		return ""
+	}
+
+	templates := templatesHolder.(templates)
+	return templates.loadBalancer + "\n"
+}
+
+func (lbd loadBalancerDetector) DetectInput(
+	manifest artifacts.InfraManifest,
+	state storage.State,
+) map[string]interface{} {
+	lb := manifest.LoadBalancer
+	result := make(map[string]interface{})
+
+	if lb == nil {
+		return result
+	}
+	result["load_balancer_sku"] = lb.SKU
+	return result
+}
+
+func newLoadBalancerDetector() loadBalancerDetector {
+	return loadBalancerDetector{}
+}


### PR DESCRIPTION
This PR adds `type Detector interface`, and its function is to detect whether a resource exists in the manifest. Currently, only two detectors are implemented, they're `loadBalancerDetector`(to detect lb) and `infraDetector`(to generate infra). If you're OK with the design, I'll add more detectors.